### PR TITLE
added grant validation

### DIFF
--- a/commonfate_provider/runtime/aws_lambda.py
+++ b/commonfate_provider/runtime/aws_lambda.py
@@ -62,6 +62,15 @@ class AWSLambdaRuntime:
 
         if isinstance(event, Grant):
             args = self.args_cls(event.data.args)
+            results = self.provider.validate_grant(event.data.subject, args)
+            for r in results.items():
+                res = dict(r[1])
+
+                if res["success"] == False:
+                    print("an error occured when validating grant")
+                    return {"message": "error validating grant"}
+                else:
+                    print("validation passed")
             grant = provider._get_grant_func()
             grant(self.provider, event.data.subject, args)
             return {"message": "granting access"}


### PR DESCRIPTION
Runs grant validation decorators before running grant.

Previously this was done as a standalone API call, but considering we are calling the lambda function for invocations I thought it might be more efficient to run the validations on the grant call, open for feedback