### PR TITLE
Adds version to get_schema call 

### DIFF
--- a/commonfate_provider/args.py
+++ b/commonfate_provider/args.py
@@ -48,7 +48,7 @@ class Args(metaclass=ModelMeta):
         return val.fetch_options(provider)
 
     @classmethod
-    def export_schema(cls) -> dict:
+    def export_schema(cls, vers) -> dict:
         """
         Exports the argument schema defined in an Args class
         to a dictionary.
@@ -71,6 +71,9 @@ class Args(metaclass=ModelMeta):
         }
         ```
         """
+
+        schema_response = {}
+        
         arg_schema = {}
         all_vars = [(k, v) for (k, v) in vars(cls).items() if not k.startswith("__")]
         for k, v in all_vars:
@@ -97,7 +100,9 @@ class Args(metaclass=ModelMeta):
 
                 arg_schema[k] = schema
 
-        return arg_schema
+        schema_response["version"] = vers
+        schema_response["schema"] = arg_schema
+        return schema_response
 
 
 class FormElement(str, Enum):

--- a/commonfate_provider/runtime/aws_lambda.py
+++ b/commonfate_provider/runtime/aws_lambda.py
@@ -77,7 +77,7 @@ class AWSLambdaRuntime:
 
         if isinstance(event, Schema):
             print("starting to get schema")
-            return {"target": self.args_cls.export_schema()}
+            return {"target": self.args_cls.export_schema(self.provider.get_version())}
 
         elif isinstance(event, LoadResources):
             resources._reset()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,14 @@
-[tool.poetry]
+[metadata]
 name = "commonfate_provider"
 version = "0.1.5"
 description = "This is the core Provider framework on top of which Access Provider are written."
 authors = ["Chris Norman <chris@commonfate.io>", "Manish Chaulagain <manish@commonfate.io>", "Josh Wilkes <josh@commonfate.io>", "Jack Meyer <jack@commonfate.io>", "Jordi Hermoso <jordi@commonfate.io>"]
 readme = "README.md"
-packages = [{include = "commonfate_provider"}]
 include = ["commonfate_provider/**/*.py"]
 ## TODO: Not excluding test from the build
 exclude = ["commonfate_provider/tests/**"]
 
-[tool.poetry.dependencies]
+[options]
 python = "^3.9"
 toml = "0.10.2"
 click = "8.1.3"
@@ -17,10 +16,3 @@ pytest = "7.2.0"
 typing-extensions = "4.4.0"
 pydantic = "1.10.2"
 treelib = "1.6.1"
-
-[tool.poetry.group.dev.dependencies]
-pre-commit = "^2.21.0"
-
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Version is now set in the providers provider.toml file and read in during the providers initialization. Allowing it to be referenced when getting the schema

Made some updates to the pyproject.toml to allow it to be worked with using the new devcli