### PR TITLE
update resource and task schema

### DIFF
--- a/commonfate_provider/resources.py
+++ b/commonfate_provider/resources.py
@@ -11,13 +11,22 @@ def composite_id(fields: typing.List[str]):
 
 class Resource(BaseModel):
     id: str
+    name: str
 
     def __init_subclass__(cls) -> None:
         namespace.register_resource_class(cls)
         return super().__init_subclass__()
 
     def export_json(self) -> dict:
-        return {"type": self.__class__.__name__, "data": dict(self)}
+        data = dict(self)
+        id = data.pop("id")
+        name = data.pop("name")
+        output = {"type": self.__class__.__name__, "id": id, "name": name, "data": data}
+        return output
+
+
+class Name:
+    pass
 
 
 T = typing.TypeVar("T", bound=Resource)
@@ -31,7 +40,7 @@ def Related(
     return Field(relatedTo=to, title=title, description=description)
 
 
-def fetcher(func: tasks.LoaderFunc):
+def loader(func: tasks.LoaderFunc):
     namespace.register_resource_loader(func)
     return func
 

--- a/commonfate_provider/runtime/aws_lambda.py
+++ b/commonfate_provider/runtime/aws_lambda.py
@@ -55,6 +55,23 @@ class Event(BaseModel):
 _T = typing.TypeVar("_T")
 
 
+class DescribeResponse(BaseModel):
+    provider: dict
+    config: dict
+    diagnostics: typing.List[dict]
+    healthy: bool
+    provider_schema: dict = Field(alias="schema")
+
+
+class LoadResponse(BaseModel):
+    resources: typing.List[dict]
+    tasks: typing.List[dict]
+
+
+class Result(BaseModel):
+    response: typing.Union[DescribeResponse, LoadResponse]
+
+
 @dataclass
 class AWSLambdaRuntime:
     provider: provider.Provider
@@ -63,6 +80,11 @@ class AWSLambdaRuntime:
     publisher: typing.Optional[str] = None
 
     def handle(self, event, context):
+        result = self._do_handle(event=event, context=context)
+        if result is not None:
+            return result.dict(by_alias=True)
+
+    def _do_handle(self, event, context) -> typing.Optional[Result]:
         parsed = Event.parse_obj(event)
         event = parsed.__root__
 
@@ -80,7 +102,7 @@ class AWSLambdaRuntime:
             args = target._initialise(args_cls, event.data.target.arguments)
             grant = registered_target.get_grant_func()
             grant(self.provider, event.data.subject, args)
-            return {"message": "granting access"}
+            return None
 
         elif isinstance(event, Revoke):
             try:
@@ -97,21 +119,29 @@ class AWSLambdaRuntime:
 
             revoke = registered_target.get_revoke_func()
             revoke(self.provider, event.data.subject, args)
-            return {"message": "revoking access"}
+            return None
+
         if isinstance(event, Describe):
             # Describe returns the configuration of the provider including the current status.
-            result = {}
-            result["provider"] = {
+            provider = {
                 "publisher": self.publisher,
                 "name": self.name,
                 "version": self.version,
             }
-            result["config"] = self.provider._safe_config
-            result["diagnostics"] = self.provider.diagnostics.export_logs()
-            result["healthy"] = self.provider.diagnostics.has_no_errors()
-            result["schema"] = schema.export_schema().dict(exclude_none=True)
+            config = self.provider._safe_config
+            diagnostics = self.provider.diagnostics.export_logs()
+            healthy = self.provider.diagnostics.has_no_errors()
+            provider_schema = schema.export_schema().dict(exclude_none=True)
 
-            return {"body": result}
+            response = DescribeResponse(
+                config=config,
+                diagnostics=diagnostics,
+                healthy=healthy,
+                provider=provider,
+                schema=provider_schema,
+            )
+
+            return Result(response=response)
 
         elif isinstance(event, Load):
             resources._reset()
@@ -122,11 +152,13 @@ class AWSLambdaRuntime:
             # find the resources and pending tasks, and return them
             found = resources.get()
             pending_tasks = tasks.get()
-            response = {
-                "resources": [r.export_json() for r in found],
-                "tasks": [t.json() for t in pending_tasks],
-            }
-            return {"body": response}
+
+            response = LoadResponse(
+                resources=[r.export_json() for r in found],
+                tasks=[t.json() for t in pending_tasks],
+            )
+
+            return Result(response=response)
 
         else:
             raise Exception(f"unhandled event type")

--- a/commonfate_provider/runtime/tests/__snapshots__/aws_lambda_test/test_load_works.json
+++ b/commonfate_provider/runtime/tests/__snapshots__/aws_lambda_test/test_load_works.json
@@ -1,0 +1,23 @@
+{
+  "body": {
+    "resources": [
+      {
+        "data": {
+          "val": "first"
+        },
+        "id": "123",
+        "name": "name",
+        "type": "MyResource"
+      },
+      {
+        "data": {
+          "val": "second"
+        },
+        "id": "456",
+        "name": "resource name",
+        "type": "MyResource"
+      }
+    ],
+    "tasks": []
+  }
+}

--- a/commonfate_provider/runtime/tests/__snapshots__/aws_lambda_test/test_load_works.json
+++ b/commonfate_provider/runtime/tests/__snapshots__/aws_lambda_test/test_load_works.json
@@ -1,5 +1,5 @@
 {
-  "body": {
+  "response": {
     "resources": [
       {
         "data": {

--- a/commonfate_provider/runtime/tests/__snapshots__/aws_lambda_test/test_provider_describe.json
+++ b/commonfate_provider/runtime/tests/__snapshots__/aws_lambda_test/test_provider_describe.json
@@ -1,5 +1,5 @@
 {
-  "body": {
+  "response": {
     "config": {},
     "diagnostics": [],
     "healthy": true,

--- a/commonfate_provider/runtime/tests/__snapshots__/aws_lambda_test/test_provider_describe_with_config.json
+++ b/commonfate_provider/runtime/tests/__snapshots__/aws_lambda_test/test_provider_describe_with_config.json
@@ -1,5 +1,5 @@
 {
-  "body": {
+  "response": {
     "config": {
       "api_key": "dict://api_key",
       "api_url": "https://example.com"

--- a/commonfate_provider/runtime/tests/__snapshots__/aws_lambda_test/test_provider_describe_with_errors.json
+++ b/commonfate_provider/runtime/tests/__snapshots__/aws_lambda_test/test_provider_describe_with_errors.json
@@ -1,5 +1,5 @@
 {
-  "body": {
+  "response": {
     "config": {
       "api_key": "dict://api_key",
       "api_url": "https://example.com"

--- a/commonfate_provider/tasks.py
+++ b/commonfate_provider/tasks.py
@@ -40,7 +40,7 @@ def call(task: Task):
     _PENDING_TASKS.append(task)
 
 
-def _execute(provider: provider.Provider, name: str, ctx: typing.Optional[dict]):
+def _execute(provider: provider.Provider, task: str, ctx: typing.Optional[dict]):
     """
     Actually execute a task.
 
@@ -51,7 +51,7 @@ def _execute(provider: provider.Provider, name: str, ctx: typing.Optional[dict])
     Top-level resource loaders do not accept any context values.
     """
     # check if we have a top-level resource loader registered under the name
-    resource_loader = namespace._RESOURCE_LOADERS.get(name)
+    resource_loader = namespace._RESOURCE_LOADERS.get(task)
     if resource_loader is not None:
         return resource_loader(provider)
 
@@ -60,12 +60,12 @@ def _execute(provider: provider.Provider, name: str, ctx: typing.Optional[dict])
 
     for Klass in Task.__subclasses__():
         # todo: handle ambiguity in task class naming
-        if Klass.__name__ == name:
+        if Klass.__name__ == task:
             task = Klass(**ctx)
             return task.run(provider)
 
     # if we get here, we couldn't find the task.
-    raise Exception(f"could not find task {name}")
+    raise Exception(f"could not find task {task}")
 
 
 def get() -> typing.List[Task]:

--- a/commonfate_provider/tests/__snapshots__/schema_test/test_schema_with_config.json
+++ b/commonfate_provider/tests/__snapshots__/schema_test/test_schema_with_config.json
@@ -24,6 +24,10 @@
             "title": "Id",
             "type": "string"
           },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
           "some_val": {
             "title": "Some Val",
             "type": "string"
@@ -31,6 +35,7 @@
         },
         "required": [
           "id",
+          "name",
           "some_val"
         ],
         "title": "ConfigResource",

--- a/commonfate_provider/tests/resources_test.py
+++ b/commonfate_provider/tests/resources_test.py
@@ -26,7 +26,7 @@ class SecondResource(resources.Resource):
     related_field: typing.Optional[str] = resources.Related(FirstResource)
 
 
-@resources.fetcher
+@resources.loader
 def load_resources():
     pass
 

--- a/commonfate_provider/tests/storage_test.py
+++ b/commonfate_provider/tests/storage_test.py
@@ -13,7 +13,7 @@ class ExampleResource(resources.Resource):
 
 
 def test_resource_equality():
-    first = ExampleResource(id="test", value="test")
-    second = ExampleResource(id="test", value="test")
+    first = ExampleResource(id="test", name="test", value="test")
+    second = ExampleResource(id="test", name="test", value="test")
     assert first.__eq__ is not None
     assert first == second


### PR DESCRIPTION
- remove camelCase "loadResources" - replace with "load". Aiming to avoid confusion here as Python standardises on `snake_case`.
- make resource names required
- lift ID and name up, out of resource data
- add test for resource fetching endpoint