### PR TITLE
fix response type and add snapshot coverage

### DIFF
--- a/commonfate_provider/runtime/tests/__snapshots__/aws_lambda_test/test_load_works_with_subtasks.json
+++ b/commonfate_provider/runtime/tests/__snapshots__/aws_lambda_test/test_load_works_with_subtasks.json
@@ -1,0 +1,13 @@
+{
+  "response": {
+    "resources": [],
+    "tasks": [
+      {
+        "ctx": {
+          "val": "test"
+        },
+        "task": "MyTask"
+      }
+    ]
+  }
+}

--- a/commonfate_provider/tasks.py
+++ b/commonfate_provider/tasks.py
@@ -15,7 +15,7 @@ class Task(metaclass=ModelMeta):
         setattr(self, "__dict__", data)
 
     def json(self) -> dict:
-        return {"name": self.__class__.__name__, "ctx": self.__dict__}
+        return {"task": self.__class__.__name__, "ctx": self.__dict__}
 
     def run(self, p) -> None:
         """


### PR DESCRIPTION
Updated already in https://github.com/common-fate/provider-registry-sdk-go/pull/12. Missed in the original schema update -  I have added snapshot coverage over this.