### PR TITLE
Fix  'String' object has no attribute '_value' error message 

### DIFF
--- a/provider/__init__.py
+++ b/provider/__init__.py
@@ -13,11 +13,21 @@ class Field:
 
 
 class String(Field):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._value = None
+
     def set(self, val: str) -> None:
         self._value = val
 
     def get(self) -> str:
+        if self._value is None and not self.optional:
+            raise FieldError("A required config value is not set")
         return self._value
+
+
+class FieldError(Exception):
+    pass
 
 
 class Provider(ABC):

--- a/provider/tests/provider_test.py
+++ b/provider/tests/provider_test.py
@@ -22,3 +22,11 @@ def test_export_schema_works(example_provider):
     got = ExampleProvider.export_config_schema()
     want = {"value": {"type": "string", "description": None, "secret": False}}
     assert got == want
+
+
+def test_config_value_missing(example_provider):
+    ExampleProvider = example_provider
+    p = ExampleProvider()
+    with pytest.raises(Exception) as exc_info:
+        p.value.get()
+    assert str(exc_info.value) == "A required config value is not set"


### PR DESCRIPTION
The error`AttributeError: 'String' object has no attribute '_value'` happens when a config value is missing in the provider which does not provide for the best developer experience. 

Updated the code to throw an exception that specifies that the config values are missing and created a test to confirm that it is working

Linear: https://linear.app/common-fate/issue/SOL-62/fix-attributeerror-string-object-has-no-attribute-value-to-give-better
